### PR TITLE
Fixing invalid frequency error with newest pandas update

### DIFF
--- a/solardatatools/data_handler.py
+++ b/solardatatools/data_handler.py
@@ -636,7 +636,7 @@ class DataHandler:
                 # Related to this bug fix:
                 # https://github.com/NatLabRockies/solar-data-tools/commit/ae0037771c09ace08bff5a4904475da606e934da
                 old_index = self.data_frame.index.copy()
-                self.data_frame.index = self.data_frame.index.shift(tz_offset, freq="H")
+                self.data_frame.index = self.data_frame.index.shift(tz_offset, freq="h")
                 self.data_frame = self.data_frame.reindex(
                     index=old_index, method="nearest", limit=1
                 ).fillna(0)

--- a/solardatatools/time_axis_manipulation.py
+++ b/solardatatools/time_axis_manipulation.py
@@ -179,7 +179,7 @@ def standardize_time_axis(
     # then apply a correction
     if correct_tz and power_col is not None:
         if np.abs(sn_deviation) > 4:
-            df.index = df.index.shift(sn_deviation, freq="H")
+            df.index = df.index.shift(sn_deviation, freq="h")
         else:
             sn_deviation = 0
     else:


### PR DESCRIPTION
This PR fixes the following error that occurs with the most recent pandas update:

```
ValueError: Invalid frequency: H. Failed to parse with error message: ValueError("Invalid frequency: H. Failed to parse with error message: KeyError('H'). Did you mean h?") Did you mean h?
```


